### PR TITLE
Added validates_presence_of method validator

### DIFF
--- a/adama.gemspec
+++ b/adama.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry"
 end

--- a/lib/adama.rb
+++ b/lib/adama.rb
@@ -1,4 +1,3 @@
-require "pry"
 require "adama/version"
 require "adama/errors"
 require "adama/validator"

--- a/lib/adama.rb
+++ b/lib/adama.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require "adama/version"
 require "adama/errors"
 require "adama/validator"

--- a/lib/adama.rb
+++ b/lib/adama.rb
@@ -1,4 +1,6 @@
+require "pry"
 require "adama/version"
 require "adama/errors"
+require "adama/validator"
 require "adama/command"
 require "adama/invoker"

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -16,7 +16,7 @@ module Adama
     # Internal: Install Command's behavior in the given class.
     def self.included(base)
       base.class_eval do
-        include Validator
+        prepend Validator
         extend ClassMethods
         attr_reader :kwargs
       end
@@ -31,7 +31,6 @@ module Adama
 
     def initialize(**kwargs)
       @kwargs = kwargs
-      validate_attributes! kwargs
     end
 
     # Internal instance method. Called by both the call class method, and by

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -16,6 +16,7 @@ module Adama
     # Internal: Install Command's behavior in the given class.
     def self.included(base)
       base.class_eval do
+        include Validator
         extend ClassMethods
         attr_reader :kwargs
       end
@@ -23,13 +24,24 @@ module Adama
 
     module ClassMethods
       # public invoke a command
-      def call(kwargs = {})
-        new(kwargs).tap(&:run)
+      def call(**kwargs)
+        new(**kwargs).tap(&:run)
       end
     end
 
-    def initialize(kwargs = {})
+    def initialize(**kwargs)
       @kwargs = kwargs
+      insert_kwarg_attributes(kwargs)
+    end
+
+    def insert_kwarg_attributes(kwargs)
+      kwargs.each do |key, value|
+        instance_variable_set "@#{key}", value
+
+        self.class.class_eval do
+          attr_accessor :"#{key}"
+        end
+      end
     end
 
     # Internal instance method. Called by both the call class method, and by

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -31,17 +31,7 @@ module Adama
 
     def initialize(**kwargs)
       @kwargs = kwargs
-      insert_kwarg_attributes(kwargs)
-    end
-
-    def insert_kwarg_attributes(kwargs)
-      kwargs.each do |key, value|
-        instance_variable_set "@#{key}", value
-
-        self.class.class_eval do
-          attr_accessor :"#{key}"
-        end
-      end
+      validate_attributes! kwargs
     end
 
     # Internal instance method. Called by both the call class method, and by

--- a/lib/adama/validator.rb
+++ b/lib/adama/validator.rb
@@ -1,0 +1,74 @@
+module Adama
+  module Validator
+    def self.included(base)
+      base.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module ClassMethods
+      def validates_presence_of(*attributes)
+        validators << PresenceValidator.new(*attributes)
+      end
+
+      def validators
+        @validators ||= []
+      end
+    end
+
+    module InstanceMethods
+      def errors
+        @errors ||= {}
+      end
+
+      def valid?
+        @valid
+      end
+
+      def validate!
+        @valid = true
+        self.class.validators.each do |validator|
+          validator.validate! self
+          merge_errors validator.errors
+          @valid = validator.valid? && @valid
+        end
+      end
+
+      private
+
+      def merge_errors(new_errors)
+        errors.merge!(new_errors) do |key, oldval, newval|
+          (newval.is_a?(Array) ? (oldval + newval) : (oldval << newval)).uniq
+        end
+      end
+    end
+
+    class PresenceValidator
+      attr_accessor :errors
+
+      def initialize(*attributes)
+        @attributes = attributes.flatten
+        @errors = {}
+      end
+
+      def valid?
+        @valid
+      end
+
+      def validate!(instance)
+        @valid = true
+        @attributes.each do |attribute|
+          @valid = attr_accessor_exists?(instance, attribute) && @valid
+        end
+      end
+
+      def attr_accessor_exists?(instance, attribute)
+        exists = instance.respond_to?(attribute) &&
+          instance.respond_to?("#{attribute}=".to_sym)
+        @errors[attribute] = ['attribute missing'] unless exists
+        exists
+      end
+    end
+  end
+end

--- a/lib/adama/validator.rb
+++ b/lib/adama/validator.rb
@@ -3,6 +3,7 @@ module Adama
     def self.included(base)
       base.class_eval do
         extend ClassMethods
+        attr_reader :kwargs
       end
     end
 
@@ -13,6 +14,21 @@ module Adama
 
       def validators
         @validators ||= []
+      end
+    end
+
+    def validate_attributes! kwargs
+      create_attributes kwargs
+      validate!
+    end
+
+    def create_attributes kwargs
+      kwargs.each do |key, value|
+        instance_variable_set "@#{key}", value
+
+        self.class.class_eval do
+          attr_accessor :"#{key}"
+        end
       end
     end
 

--- a/lib/adama/validator.rb
+++ b/lib/adama/validator.rb
@@ -3,7 +3,6 @@ module Adama
     def self.included(base)
       base.class_eval do
         extend ClassMethods
-        include InstanceMethods
       end
     end
 
@@ -17,30 +16,28 @@ module Adama
       end
     end
 
-    module InstanceMethods
-      def errors
-        @errors ||= {}
+    def errors
+      @errors ||= {}
+    end
+
+    def valid?
+      @valid
+    end
+
+    def validate!
+      @valid = true
+      self.class.validators.each do |validator|
+        validator.validate! self
+        merge_errors validator.errors
+        @valid = validator.valid? && @valid
       end
+    end
 
-      def valid?
-        @valid
-      end
+    private
 
-      def validate!
-        @valid = true
-        self.class.validators.each do |validator|
-          validator.validate! self
-          merge_errors validator.errors
-          @valid = validator.valid? && @valid
-        end
-      end
-
-      private
-
-      def merge_errors(new_errors)
-        errors.merge!(new_errors) do |key, oldval, newval|
-          (newval.is_a?(Array) ? (oldval + newval) : (oldval << newval)).uniq
-        end
+    def merge_errors(new_errors)
+      errors.merge!(new_errors) do |key, oldval, newval|
+        (newval.is_a?(Array) ? (oldval + newval) : (oldval << newval)).uniq
       end
     end
 

--- a/lib/adama/validator.rb
+++ b/lib/adama/validator.rb
@@ -1,35 +1,35 @@
 module Adama
   module Validator
-    def self.included(base)
-      base.class_eval do
-        extend ClassMethods
-        attr_reader :kwargs
-      end
+    def self.prepended(base)
+      base.extend ClassMethods
     end
 
     module ClassMethods
       def validates_presence_of(*attributes)
-        validators << PresenceValidator.new(*attributes)
+        # Assign the validator if it exists, ortherwise create a new one and
+        # append it to the validators array
+        unless validator = validators.find { |v| v.is_a? PresenceValidator }
+          validator = PresenceValidator.new
+          validators << validator
+        end
+
+        # Append the passed in attributes. This will result in a list
+        # of unique attributes.
+        validator.merge_new_attributes(*attributes)
       end
 
+      # Maintain an array of validators
       def validators
         @validators ||= []
       end
     end
 
-    def validate_attributes! kwargs
-      create_attributes kwargs
+    # This module is meant to be prepended to another module
+    # Call the child class initializer first, this will set kwargs
+    # Then validate
+    def initialize(**kwargs)
+      super(**kwargs)
       validate!
-    end
-
-    def create_attributes kwargs
-      kwargs.each do |key, value|
-        instance_variable_set "@#{key}", value
-
-        self.class.class_eval do
-          attr_accessor :"#{key}"
-        end
-      end
     end
 
     def errors
@@ -40,6 +40,9 @@ module Adama
       @valid
     end
 
+    # Iterate over the validators registered, and for each validator
+    # call `validate!` passing in the instance of the class this module
+    # was prepended to.
     def validate!
       @valid = true
       self.class.validators.each do |validator|
@@ -51,6 +54,7 @@ module Adama
 
     private
 
+    # Create a uniform error output, per attribute
     def merge_errors(new_errors)
       errors.merge!(new_errors) do |key, oldval, newval|
         (newval.is_a?(Array) ? (oldval + newval) : (oldval << newval)).uniq
@@ -69,18 +73,27 @@ module Adama
         @valid
       end
 
+      def merge_new_attributes(*attributes)
+        @attributes |= attributes
+      end
+
       def validate!(instance)
         @valid = true
+        kwargs = instance.kwargs
         @attributes.each do |attribute|
-          @valid = attr_accessor_exists?(instance, attribute) && @valid
+          present = kwargs.include? attribute
+          if present
+            set_instance_variable instance, attribute, kwargs[attribute]
+          else
+            @errors[attribute] = ['attribute missing']
+          end
+          @valid = present && @valid
         end
       end
 
-      def attr_accessor_exists?(instance, attribute)
-        exists = instance.respond_to?(attribute) &&
-          instance.respond_to?("#{attribute}=".to_sym)
-        @errors[attribute] = ['attribute missing'] unless exists
-        exists
+      def set_instance_variable(instance, key, value)
+        instance.instance_variable_set "@#{key}", value
+        instance.class.class_eval { attr_accessor :"#{key}" }
       end
     end
   end

--- a/spec/adama/command_examples.rb
+++ b/spec/adama/command_examples.rb
@@ -19,13 +19,6 @@ shared_examples :command_base do
 
       it { expect(klass).to have_received(:new).once.with(kwargs) }
       it { expect(instance).to have_received(:run).once.with(no_args) }
-
-      it 'sets the correct instance methods' do
-        kwargs.each do |key, val|
-          expect(instance.methods).to include key
-          expect(instance.send(key)).to eq val
-        end
-      end
     end
 
     describe '.call without args' do

--- a/spec/adama/command_examples.rb
+++ b/spec/adama/command_examples.rb
@@ -1,48 +1,64 @@
 shared_examples :command_base do
-  let(:command) { Class.new.send(:include, described_class) }
+  context 'command examples' do
+    let(:klass)    { Class.new.send(:include, described_class) }
+    let(:kwargs)   { {} }
+    let(:instance) { klass.new kwargs}
 
-  describe '.new' do
-    let(:instance) { command.new(foo: 'bar') }
-
-    it { expect(instance).to be_a(command) }
-  end
-
-  describe '.call' do
-    let(:instance) { instance_double(command) }
-    subject        { command.call(foo: 'bar') }
-
-    before do
-      allow(command).to receive(:new).and_return(instance)
-      allow(instance).to receive(:run)
-      subject
+    describe '.new' do
+      it { expect(instance).to be_a(klass) }
     end
 
-    it { expect(command).to have_received(:new).once.with(foo: 'bar') }
-    it { expect(instance).to have_received(:run).once.with(no_args) }
-  end
+    describe '.call with kwargs' do
+      let(:kwargs) { { foo: 'bar', key: 'val' } }
 
-  describe '#run' do
-    let(:instance) { command.new }
-    subject        { instance.run }
-
-    context 'when the call is successful' do
       before do
-        allow(instance).to receive(:run).once.with(no_args)
-        subject
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:run)
+        klass.call(kwargs)
       end
 
+      it { expect(klass).to have_received(:new).once.with(kwargs) }
+      it { expect(instance).to have_received(:run).once.with(no_args) }
+
+      it 'sets the correct instance methods' do
+        kwargs.each do |key, val|
+          expect(instance.methods).to include key
+          expect(instance.send(key)).to eq val
+        end
+      end
+    end
+
+    describe '.call without args' do
+      before do
+        allow(klass).to receive(:new).and_return(instance)
+        allow(instance).to receive(:run)
+        klass.call
+      end
+
+      it { expect(klass).to have_received(:new).once.with({}) }
       it { expect(instance).to have_received(:run).once.with(no_args) }
     end
 
-    context 'when the call raises an error' do
-      before do
-        allow(instance).to receive(:call).and_raise(StandardError)
-        allow(instance).to receive(:rollback)
+    describe '#run' do
+      context 'when the call is successful' do
+        before do
+          allow(instance).to receive(:run).once.with(no_args)
+          instance.run
+        end
+
+        it { expect(instance).to have_received(:run).once.with(no_args) }
       end
 
-      it 'raises the error, then calls rollback' do
-        expect { instance.run }.to raise_error(Adama::Errors::BaseError) do |_error|
-          expect(instance).to have_received(:rollback).once.with(no_args)
+      context 'when the call raises an error' do
+        before do
+          allow(instance).to receive(:call).and_raise(StandardError)
+          allow(instance).to receive(:rollback)
+        end
+
+        it 'raises the error, then calls rollback' do
+          expect { instance.run }.to raise_error(Adama::Errors::BaseError) do |_error|
+            expect(instance).to have_received(:rollback).once.with(no_args)
+          end
         end
       end
     end

--- a/spec/adama/command_spec.rb
+++ b/spec/adama/command_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
+require_relative 'validator_examples'
 require_relative 'command_examples'
 
 RSpec.describe Adama::Command do
+  include_examples :validator_base
   include_examples :command_base
 end

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
+require_relative 'validator_examples'
 require_relative 'command_examples'
 
 RSpec.describe Adama::Invoker do
+  include_examples :validator_base
   include_examples :command_base
 
   before(:context) do
@@ -39,10 +41,13 @@ RSpec.describe Adama::Invoker do
 
     it 'calls .new on the commands in order' do
       Invoker.call(**kwargs)
-      expect(Command1).to have_received(:new).with(**kwargs).ordered
-      expect(Command2).to have_received(:new).with(**kwargs).ordered
-      expect(Command3).to have_received(:new).with(**kwargs).ordered
-      expect(Command4).to have_received(:new).with(**kwargs).ordered
+      expect(Command1).to have_received(:new).ordered
+      expect(Command2).to have_received(:new).ordered
+      expect(Command3).to have_received(:new).ordered
+      expect(Command4).to have_received(:new).ordered
+
+      kwargs.each do |key, value|
+      end
     end
 
     it 'calls .call on the commands in order' do

--- a/spec/adama/validator_examples.rb
+++ b/spec/adama/validator_examples.rb
@@ -17,7 +17,8 @@ shared_examples :validator_base do
 
       context 'when we validate a correctly passed in kwarg' do
         before do
-          klass.send(:validates_presence_of, [:foo, :key, :jar])
+          klass.validates_presence_of :foo, :key, :jar
+          klass.validates_presence_of :jar, :jar, :binks
           instance.validate!
         end
 
@@ -25,7 +26,8 @@ shared_examples :validator_base do
         it 'sets the correct errors' do
           expect(instance.errors).to eq({
             key: ['attribute missing'],
-            jar: ['attribute missing']
+            jar: ['attribute missing'],
+            binks: ['attribute missing']
           })
         end
       end

--- a/spec/adama/validator_examples.rb
+++ b/spec/adama/validator_examples.rb
@@ -1,0 +1,34 @@
+shared_examples :validator_base do
+  context 'validator examples' do
+    let(:klass)    { Class.new.send(:include, described_class) }
+    let(:kwargs)   { { foo: 'bar' } }
+    let(:instance) { klass.new kwargs }
+
+    describe '.validates_presence_of' do
+      context 'when we validate a correctly passed in kwarg' do
+        before do
+          klass.send(:validates_presence_of, :foo)
+          instance.validate!
+        end
+
+        it { expect(instance.valid?).to be true }
+        it { expect(instance.errors).to be_empty }
+      end
+
+      context 'when we validate a correctly passed in kwarg' do
+        before do
+          klass.send(:validates_presence_of, [:foo, :key, :jar])
+          instance.validate!
+        end
+
+        it { expect(instance.valid?).to be false }
+        it 'sets the correct errors' do
+          expect(instance.errors).to eq({
+            key: ['attribute missing'],
+            jar: ['attribute missing']
+          })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Taking inspiration from @paulfri's comment on setting the passed in kwargs as instance attributes on the commands, and adding a very simple validation class allowing us to validate presence of an attribute.

```ruby
class DestroyCylons
  include Adama::Command

  validates_presence_of :captain

  def call
    puts captain
    # "Lee Adama"
    got_destroy_cylons(captain)
  end

  def rollback
    retreat_and_jump_away()
  end
end
```