### PR TITLE
Add descriptive string representation of Adama errors

### DIFF
--- a/lib/adama/errors.rb
+++ b/lib/adama/errors.rb
@@ -3,10 +3,14 @@ module Adama
     class BaseError < StandardError
       attr_reader :error, :command, :invoker
 
-      def initialize(error: nil, command: nil, invoker: nil)
+      def initialize(error:, command:, invoker: nil)
         @error = error
         @command = command
         @invoker = invoker
+      end
+
+      def to_s
+        "#{command.class.name} failed with #{error.class}: #{error.message}"
       end
     end
     class CommandError < BaseError; end

--- a/spec/adama/errors_spec.rb
+++ b/spec/adama/errors_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Adama::Errors::BaseError do
+  describe '#to_s' do
+    subject(:error_string) { described_class.new(error: error, command: command).to_s }
+    before(:all) { Object.const_set('TestCommand', Class.new.send(:include, Adama::Command)) }
+    let(:error) { StandardError.new('test message') }
+    let(:command) { TestCommand.new }
+
+    it 'contains the class name and message of the wrapped error' do
+      expect(error_string).to match /StandardError: test message/
+    end
+
+    it 'contains the class of of the failed command' do
+      expect(error_string).to match /TestCommand/
+    end
+  end
+end


### PR DESCRIPTION
Provides a description of the command that failed and the wrapped error class and message that caused the failure. This description can be accessed via the `#message` method on the
error or via `#to_s`

I also made the `error` and `command` keyword args required when instantiating an adama error since we should always have those available.

@dradford want me to add a version bump with this PR?