### PR TITLE
Failed commands don't rollback

### DIFF
--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -34,12 +34,10 @@ module Adama
     end
 
     # Internal instance method. Called by both the call class method, and by
-    # the call method in the invoker. If it fails it rolls back the command
-    # and raises a CommandError.
-    def run(enable_rollback: true)
+    # the call method in the invoker. If it fails it raises a CommandError.
+    def run
       call
     rescue => error
-      rollback if enable_rollback
       raise Errors::CommandError.new error: error, command: self
     end
 

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -98,17 +98,13 @@ module Adama
         end
       end
 
-      # Iterate over the commands array, instantiate each command, add it to
-      # the called list and then run it. We don't want the command to call
-      # rollback itself as that will be handled by the rollback method above.
-      # To ensure this doesn't happen we pass in enable_rollback: false.
-      # Please ensure the command is placed on the array _prior_ to calling
-      # run, or else we'll miss rolling back the command that failed.
+      # Iterate over the commands array, instantiate each command, run it,
+      # and add it to the called list.
       def call
         self.class.commands.each do |command_klass|
           command = command_klass.new(kwargs)
+          command.run
           _called << command
-          command.run(enable_rollback: false)
         end
       end
     end

--- a/spec/adama/command_examples.rb
+++ b/spec/adama/command_examples.rb
@@ -45,13 +45,10 @@ shared_examples :command_base do
       context 'when the call raises an error' do
         before do
           allow(instance).to receive(:call).and_raise(StandardError)
-          allow(instance).to receive(:rollback)
         end
 
-        it 'raises the error, then calls rollback' do
-          expect { instance.run }.to raise_error(Adama::Errors::BaseError) do |_error|
-            expect(instance).to have_received(:rollback).once.with(no_args)
-          end
+        it 'raises the error' do
+          expect { instance.run }.to raise_error(Adama::Errors::BaseError)
         end
       end
     end

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Adama::Invoker do
 
   describe '.call' do
     before do
-      allow(instance_1).to receive(:run).with(enable_rollback: false)
-      allow(instance_2).to receive(:run).with(enable_rollback: false)
-      allow(instance_3).to receive(:run).with(enable_rollback: false)
-      allow(instance_4).to receive(:run).with(enable_rollback: false)
+      allow(instance_1).to receive(:run)
+      allow(instance_2).to receive(:run)
+      allow(instance_3).to receive(:run)
+      allow(instance_4).to receive(:run)
 
       Invoker.invoke(*command_list)
     end
@@ -52,10 +52,10 @@ RSpec.describe Adama::Invoker do
 
     it 'calls .call on the commands in order' do
       Invoker.call(**kwargs)
-      expect(instance_1).to have_received(:run).with(enable_rollback: false).ordered
-      expect(instance_2).to have_received(:run).with(enable_rollback: false).ordered
-      expect(instance_3).to have_received(:run).with(enable_rollback: false).ordered
-      expect(instance_4).to have_received(:run).with(enable_rollback: false).ordered
+      expect(instance_1).to have_received(:run).ordered
+      expect(instance_2).to have_received(:run).ordered
+      expect(instance_3).to have_received(:run).ordered
+      expect(instance_4).to have_received(:run).ordered
     end
   end
 
@@ -84,7 +84,7 @@ RSpec.describe Adama::Invoker do
         allow(instance_4).to receive(:rollback)
       end
 
-      it 'calls #rollback in reverse' do
+      it 'calls #rollback in reverse order on the commands that succeeded' do
         Invoker.invoke(*command_list)
         expect { Invoker.call(**kwargs) }
           .to raise_error(Adama::Errors::InvokerError) do |error|
@@ -97,10 +97,11 @@ RSpec.describe Adama::Invoker do
           expect(instance_3).to have_received(:call).with(no_args).ordered
           expect(instance_4).to have_received(:call).with(no_args).ordered
 
-          expect(instance_4).to have_received(:rollback).with(no_args).ordered
           expect(instance_3).to have_received(:rollback).with(no_args).ordered
           expect(instance_2).to have_received(:rollback).with(no_args).ordered
           expect(instance_1).to have_received(:rollback).with(no_args).ordered
+
+          expect(instance_4).not_to have_received(:rollback).with(no_args)
         end
       end
     end


### PR DESCRIPTION
Hey @dradford realized we were doing rollbacks differently than Interactor when we I was looking into the rollback error stuff. This PR updates command logic in two ways
- When a command fails it does not call its rollback method
- When an invoked command fails, the invoker does not roll
  it back (but it does roll back the commands prior to it
  that succeeded)

This follows from the idea that a command should have one responsibility so if it fails it does not need to be rolled back. This is how the interactor gem handles it: https://github.com/collectiveidea/interactor#rollback

We need this behavior for Adama to work as a drop-in replacement for Interactor