### PR TITLE
Preserve original error backtrace in wrapped error

### DIFF
--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -36,9 +36,14 @@ module Adama
     # Internal instance method. Called by both the call class method, and by
     # the call method in the invoker. If it fails it raises a CommandError.
     def run
+      command_caller = caller
       call
     rescue => error
-      raise Errors::CommandError.new error: error, command: self
+      raise Errors::CommandError.new(
+        error: error,
+        command: self,
+        backtrace: error.backtrace + ['Adama Command backtrace:'] + command_caller
+      )
     end
 
     # Public instance method. Override this in classes this module is

--- a/lib/adama/errors.rb
+++ b/lib/adama/errors.rb
@@ -3,10 +3,11 @@ module Adama
     class BaseError < StandardError
       attr_reader :error, :command, :invoker
 
-      def initialize(error:, command:, invoker: nil)
+      def initialize(error:, command:, invoker: nil, backtrace: nil)
         @error = error
         @command = command
         @invoker = invoker
+        set_backtrace backtrace if backtrace
       end
 
       def to_s

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -69,13 +69,15 @@ module Adama
       # invoker "call" instance method, we won't have access to error's
       # command so need to test for it's existence.
       def run
+        command_caller = caller
         call
       rescue => error
         rollback
         raise Errors::InvokerError.new(
           error: error,
           command: error.respond_to?(:command) ? error.command : nil,
-          invoker: self
+          invoker: self,
+          backtrace: error.backtrace + ['Adama Invoker backtrace:'] + command_caller
         )
       end
 
@@ -93,7 +95,7 @@ module Adama
           begin
             command.rollback
           rescue => error
-            raise Errors::InvokerRollbackError.new(error: error, command: command, invoker: self)
+            raise Errors::InvokerRollbackError.new(error: error, command: command, invoker: self, backtrace: error.backtrace)
           end
         end
       end

--- a/spec/adama/command_examples.rb
+++ b/spec/adama/command_examples.rb
@@ -44,11 +44,20 @@ shared_examples :command_base do
 
       context 'when the call raises an error' do
         before do
-          allow(instance).to receive(:call).and_raise(StandardError)
+          error = StandardError.new.tap { |e| e.set_backtrace 'original error backtrace' }
+          allow(instance).to receive(:call).and_raise(error)
         end
 
         it 'raises the error' do
           expect { instance.run }.to raise_error(Adama::Errors::BaseError)
+        end
+
+        it 'contains the backtrace of the original error' do
+          begin
+            instance.run
+          rescue => e
+            expect(e.backtrace).to include 'original error backtrace'
+          end
         end
       end
     end


### PR DESCRIPTION
@dradford as of right now adama loses the backtrace of the original error raised when it wraps the error. This updates the Adama backtrace to contain the backtrace of the original error with its own backtrace added to the end.