### PR TITLE
Remove Inovker/Command backtrace

### DIFF
--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -36,7 +36,6 @@ module Adama
     # Internal instance method. Called by both the call class method, and by
     # the call method in the invoker. If it fails it raises a CommandError.
     def run
-      command_caller = caller
       call
     rescue => error
       raise Errors::CommandError.new(

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -42,7 +42,7 @@ module Adama
       raise Errors::CommandError.new(
         error: error,
         command: self,
-        backtrace: error.backtrace + ['Adama Command backtrace:'] + command_caller
+        backtrace: error.backtrace
       )
     end
 

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -69,7 +69,6 @@ module Adama
       # invoker "call" instance method, we won't have access to error's
       # command so need to test for it's existence.
       def run
-        command_caller = caller
         call
       rescue => error
         rollback

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -77,7 +77,7 @@ module Adama
           error: error,
           command: error.respond_to?(:command) ? error.command : nil,
           invoker: self,
-          backtrace: error.backtrace + ['Adama Invoker backtrace:'] + command_caller
+          backtrace: error.backtrace
         )
       end
 


### PR DESCRIPTION
This feature is extremely noisy in practice. I think this makes sense for development of the gem, but in application code it makes it really distracting when tracking down legit backtraces