### PR TITLE
Support Instance Invoker Run Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ Now, when you run `RebuildHumanRace.call(captain: :apollo, president: :laura)` i
 
 If there is an error in any of those commands, the invoker will call `FindEarth.rollback`, then `DestroyCylons.rollback`, then `GetArrowOfApollo.rollback` leaving everything just as it was in the beginning.
 
+#### Instance Invoker List
+
+Typically your Invoker class takes responsibility for an immutable set of actions, however sometimes it's handy to be able to adjust the invoked commands on the fly while keeping the error handling and rollback functionality of the invoker.
+
+e.g.
+
+```ruby
+class FightCylons
+  include Adama::Invoker
+end
+
+attack1 = Invoker.new(captain: :apollo, lieutenant:  :starbuck).invoke(Advance, Strafe, Fire)
+attack2 = Invoker.new(captain: :apollo, lieutenant:  :starbuck).invoke(Advance, Fire)
+
+attack1.run
+attack2.run
+```
+
+It's important to see that we're using the `#run` instance method on the Invoker instance (as the `.call` class method would). This ensures we execute the invoker in the error / rollback handler. Calling the `#call` instance method directly would simply execute each command, without any Invoker level error handling.
+
 ### Errors
 
 `Adama::Command#call` or `Adama::Invoker#call` will *always* raise an error of type `Adama::Errors::BaseError`.

--- a/adama.gemspec
+++ b/adama.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -36,7 +36,7 @@ module Adama
     # Internal instance method. Called by both the call class method, and by
     # the call method in the invoker. If it fails it raises a CommandError.
     def run
-      self.tap(&:call)
+      tap(&:call)
     rescue => error
       raise Errors::CommandError.new(
         error: error,

--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -36,7 +36,7 @@ module Adama
     # Internal instance method. Called by both the call class method, and by
     # the call method in the invoker. If it fails it raises a CommandError.
     def run
-      call
+      self.tap(&:call)
     rescue => error
       raise Errors::CommandError.new(
         error: error,

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -50,6 +50,10 @@ module Adama
       #   )
       # end
       def invoke(*command_list)
+        if is_a?(Invoker) && self.class.commands.any?
+          raise(StandardError, 'Can\'t call invoke on an Invoker instance \
+                               with a class invocation list.')
+        end
         @commands = command_list.flatten
       end
 

--- a/lib/adama/invoker.rb
+++ b/lib/adama/invoker.rb
@@ -70,7 +70,7 @@ module Adama
       # invoker "call" instance method, we won't have access to error's
       # command so need to test for it's existence.
       def run
-        self.tap(&:call)
+        tap(&:call)
       rescue => error
         rollback
         raise Errors::InvokerError.new(

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Adama::Invoker do
     # class member var. This means that every Invoker of that
     # type calls the same comnmands.
     #
-    # The second method is to initialize a new instanvce of
+    # The second method is to initialize a new instance of
     # an invoker and pass the list of commands to invoke
     # to the instance. This means that we can dynamically
     # change the command list per Invoker instance.

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -3,9 +3,13 @@ require_relative 'validator_examples'
 require_relative 'command_examples'
 
 RSpec.describe Adama::Invoker do
+  # Run normal command spec examples for
+  # invokers because and Invoker is a glorified
+  # version of a command.
   include_examples :validator_base
   include_examples :command_base
 
+  # Configure for Invoker #invoke tests
   before(:context) do
     Object.const_set('Invoker', Class.new.send(:include, Adama::Invoker))
     Object.const_set('Command1', Class.new.send(:include, Adama::Command))
@@ -22,6 +26,8 @@ RSpec.describe Adama::Invoker do
   let(:command_list) { [Command1, Command2, Command3, Command4] }
   let(:kwargs)       { { foo: 'bar' } }
 
+  # Mock the new method on the commands to return our defined
+  # instances.
   before do
     allow(Command1).to receive(:new).and_return(instance_1)
     allow(Command2).to receive(:new).and_return(instance_2)
@@ -36,26 +42,68 @@ RSpec.describe Adama::Invoker do
       allow(instance_3).to receive(:run)
       allow(instance_4).to receive(:run)
 
-      Invoker.invoke(*command_list)
+      invokable.invoke(*command_list)
+      invoke
     end
 
-    it 'calls .new on the commands in order' do
-      Invoker.call(**kwargs)
-      expect(Command1).to have_received(:new).ordered
-      expect(Command2).to have_received(:new).ordered
-      expect(Command3).to have_received(:new).ordered
-      expect(Command4).to have_received(:new).ordered
+    shared_examples 'calls the commands in order' do
+      it 'calls .new on the commands in order' do
+        expect(Command1).to have_received(:new).ordered
+        expect(Command2).to have_received(:new).ordered
+        expect(Command3).to have_received(:new).ordered
+        expect(Command4).to have_received(:new).ordered
+      end
 
-      kwargs.each do |key, value|
+      it 'calls .call on the commands in order' do
+        expect(instance_1).to have_received(:run).ordered
+        expect(instance_2).to have_received(:run).ordered
+        expect(instance_3).to have_received(:run).ordered
+        expect(instance_4).to have_received(:run).ordered
       end
     end
 
-    it 'calls .call on the commands in order' do
-      Invoker.call(**kwargs)
-      expect(instance_1).to have_received(:run).ordered
-      expect(instance_2).to have_received(:run).ordered
-      expect(instance_3).to have_received(:run).ordered
-      expect(instance_4).to have_received(:run).ordered
+    # There are two methods of passing an Invoker a list
+    # of commands to run.
+    #
+    # The first methods sets up the command list in the class
+    # definition, which stores the array of commands as a
+    # class member var. This means that every Invoker of that
+    # type calls the same comnmands.
+    #
+    # The second method is to initialize a new instanvce of
+    # an invoker and pass the list of commands to invoke
+    # to the instance. This means that we can dynamically
+    # change the command list per Invoker instance.
+
+    context 'When an Invoker class is passed a command list' do
+      # The first method:
+      #
+      #   class Invoker
+      #     include Adama::Invoker
+      #     invoke(Command1, Command2)
+      #   end
+      #
+      #   Invoker.call(foo: bar)
+      #
+      let(:invokable) { Invoker }
+      let(:invoke) { invokable.call **kwargs }
+
+      it_behaves_like 'calls the commands in order'
+    end
+
+    context 'When an Invoker instance is passed a command list' do
+      # The second method:
+      #
+      #   class Invoker
+      #     include Adama::Invoker
+      #   end
+      #
+      #   Invoker.new(foo: bar).invoke(Command1, Command2).call
+      #
+      let(:invokable) { Invoker.new **kwargs }
+      let(:invoke) { invokable.run }
+
+      it_behaves_like 'calls the commands in order'
     end
   end
 
@@ -64,7 +112,11 @@ RSpec.describe Adama::Invoker do
       ########################
       ## Instance level mocks
 
-      # Ensure the third call fails. This will allow us to test the forward
+      # Ensure the first three calls succeed.
+      #
+      # We fail the fourth call below.
+      #
+      # This will allow us to test the forward
       # run and the reverse rollback.
       allow(instance_1).to receive(:call)
       allow(instance_2).to receive(:call)
@@ -76,33 +128,51 @@ RSpec.describe Adama::Invoker do
       allow(instance_3).to receive(:rollback)
 
       allow_any_instance_of(Invoker).to receive(:rollback).and_call_original
+
+      invokable.invoke(*command_list)
     end
 
-    context 'fourth command rollback fails' do
+    context 'fourth command call fails' do
       before do
+        # Fail the fourth call
         allow(instance_4).to receive(:call).and_raise(StandardError)
         allow(instance_4).to receive(:rollback)
       end
 
-      it 'calls #rollback in reverse order on the commands that succeeded' do
-        Invoker.invoke(*command_list)
-        expect { Invoker.call(**kwargs) }
-          .to raise_error(Adama::Errors::InvokerError) do |error|
-          expect(error.invoker).to be_a(Invoker)
-          expect(error.command).to be_a(Command4)
-          expect(error.error).to be_a(StandardError)
+      shared_examples 'rolls back in the correct order' do
+        it 'calls #rollback in reverse order on the commands that succeeded' do
+          expect { invoke }
+            .to raise_error(Adama::Errors::InvokerError) do |error|
+            expect(error.invoker).to be_a(Invoker)
+            expect(error.command).to be_a(Command4)
+            expect(error.error).to be_a(StandardError)
 
-          expect(instance_1).to have_received(:call).with(no_args).ordered
-          expect(instance_2).to have_received(:call).with(no_args).ordered
-          expect(instance_3).to have_received(:call).with(no_args).ordered
-          expect(instance_4).to have_received(:call).with(no_args).ordered
+            expect(instance_1).to have_received(:call).with(no_args).ordered
+            expect(instance_2).to have_received(:call).with(no_args).ordered
+            expect(instance_3).to have_received(:call).with(no_args).ordered
+            expect(instance_4).to have_received(:call).with(no_args).ordered
 
-          expect(instance_3).to have_received(:rollback).with(no_args).ordered
-          expect(instance_2).to have_received(:rollback).with(no_args).ordered
-          expect(instance_1).to have_received(:rollback).with(no_args).ordered
+            expect(instance_3).to have_received(:rollback).with(no_args).ordered
+            expect(instance_2).to have_received(:rollback).with(no_args).ordered
+            expect(instance_1).to have_received(:rollback).with(no_args).ordered
 
-          expect(instance_4).not_to have_received(:rollback).with(no_args)
+            expect(instance_4).not_to have_received(:rollback).with(no_args)
+          end
         end
+      end
+
+      context 'When an Invoker class is passed a command list' do
+        let(:invokable) { Invoker }
+        let(:invoke) { invokable.call **kwargs }
+
+        it_behaves_like 'rolls back in the correct order'
+      end
+
+      context 'When an Invoker instance is passed a command list' do
+        let(:invokable) { Invoker.new **kwargs }
+        let(:invoke) { invokable.run }
+
+        it_behaves_like 'rolls back in the correct order'
       end
     end
 
@@ -112,25 +182,39 @@ RSpec.describe Adama::Invoker do
         allow(instance_4).to receive(:rollback).and_raise(StandardError)
       end
 
-      it 'failed #rollback raises catastrophic rollback error' do
-        Invoker.invoke(*command_list)
-        invoker = Invoker.call(**kwargs)
-        expect { invoker.rollback }
-          .to raise_error(Adama::Errors::InvokerRollbackError) do |error|
-          expect(error.invoker).to be_a(Invoker)
-          expect(error.command).to be_a(Command4)
-          expect(error.error).to be_a(StandardError)
+      shared_examples 'fails in the correct manner' do
+        it 'failed #rollback raises catastrophic rollback error' do
+          expect { invoke.rollback }
+            .to raise_error(Adama::Errors::InvokerRollbackError) do |error|
+            expect(error.invoker).to be_a(Invoker)
+            expect(error.command).to be_a(Command4)
+            expect(error.error).to be_a(StandardError)
 
-          expect(instance_1).to have_received(:call).with(no_args).ordered
-          expect(instance_2).to have_received(:call).with(no_args).ordered
-          expect(instance_3).to have_received(:call).with(no_args).ordered
-          expect(instance_4).to have_received(:call).with(no_args).ordered
+            expect(instance_1).to have_received(:call).with(no_args).ordered
+            expect(instance_2).to have_received(:call).with(no_args).ordered
+            expect(instance_3).to have_received(:call).with(no_args).ordered
+            expect(instance_4).to have_received(:call).with(no_args).ordered
 
-          expect(instance_4).to have_received(:rollback)
-          expect(instance_3).not_to have_received(:rollback)
-          expect(instance_2).not_to have_received(:rollback)
-          expect(instance_1).not_to have_received(:rollback)
+            expect(instance_4).to have_received(:rollback)
+            expect(instance_3).not_to have_received(:rollback)
+            expect(instance_2).not_to have_received(:rollback)
+            expect(instance_1).not_to have_received(:rollback)
+          end
         end
+      end
+
+      context 'When an Invoker class is passed a command list' do
+        let(:invokable) { Invoker }
+        let(:invoke) { invokable.call **kwargs }
+
+        it_behaves_like 'fails in the correct manner'
+      end
+
+      context 'When an Invoker instance is passed a command list' do
+        let(:invokable) { Invoker.new **kwargs }
+        let(:invoke) { invokable.run }
+
+        it_behaves_like 'fails in the correct manner'
       end
     end
   end

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Adama::Invoker do
     allow(Command2).to receive(:new).and_return(instance_2)
     allow(Command3).to receive(:new).and_return(instance_3)
     allow(Command4).to receive(:new).and_return(instance_4)
+    Invoker.invoke []
+  end
+
+  describe '#invoke' do
+    let(:invokable) { Invoker }
+    before {  invokable.invoke *command_list }
+    subject { invokable.new **kwargs }
+
+    it 'does not let you call invoke on class and instance' do
+      expect { subject.invoke *command_list }
+        .to raise_error(StandardError)
+    end
   end
 
   describe '.call' do

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -98,7 +98,14 @@ RSpec.describe Adama::Invoker do
       #     include Adama::Invoker
       #   end
       #
-      #   Invoker.new(foo: bar).invoke(Command1, Command2).call
+      #   Invoker.new(foo: bar).invoke(Command1, Command2).run
+      #
+      #
+      # NOTE: WE CALL `#run` ON THE INSTANCE INSTEAD OF `#call`
+      #
+      # This is because the `#run` method is the main executor
+      # in the context of the instance, and is wrapped in the
+      # internall error handlers.
       #
       let(:invokable) { Invoker.new **kwargs }
       let(:invoke) { invokable.run }

--- a/spec/adama/invoker_spec.rb
+++ b/spec/adama/invoker_spec.rb
@@ -4,7 +4,7 @@ require_relative 'command_examples'
 
 RSpec.describe Adama::Invoker do
   # Run normal command spec examples for
-  # invokers because and Invoker is a glorified
+  # invokers because an Invoker is a glorified
   # version of a command.
   include_examples :validator_base
   include_examples :command_base


### PR DESCRIPTION
Adding support to configure an invoker instance with a dynamic `invoker` list.

### The first method

The original way, which sets the invoker command list on the class

```ruby
class Invoker
  include Adama::Invoker
  invoke(Command1, Command2)
end

Invoker.call(foo: bar)
```

### The second method

The new way, which sets the invoker command list on the instance

```ruby
class Invoker
  include Adama::Invoker
end

Invoker.new(foo: bar).invoke(Command1, Command2).run
```

Adjusted the following:

- In the Invoker `#call` instance method, check the instance for a command list then fall back to the class
- Make `run` method return self (through tap)
- Rename `ClassMethods` to `InvokerMethods` for easier understanding
- Both extend and include `InvokeMethods` to support command lists on the class and instance
- Adjust specs to handle both instance and class run lists on the Invoker

P.S. note that we call `#run` when using an instance of an Invoker, not the `#call` method