### PR TITLE
remove splat arguments

### DIFF
--- a/lib/adama/command.rb
+++ b/lib/adama/command.rb
@@ -24,12 +24,12 @@ module Adama
 
     module ClassMethods
       # public invoke a command
-      def call(**kwargs)
-        new(**kwargs).tap(&:run)
+      def call(kwargs)
+        new(kwargs).tap(&:run)
       end
     end
 
-    def initialize(**kwargs)
+    def initialize(kwargs)
       @kwargs = kwargs
     end
 

--- a/lib/adama/validator.rb
+++ b/lib/adama/validator.rb
@@ -27,8 +27,8 @@ module Adama
     # This module is meant to be prepended to another module
     # Call the child class initializer first, this will set kwargs
     # Then validate
-    def initialize(**kwargs)
-      super(**kwargs)
+    def initialize(kwargs)
+      super(kwargs)
       validate!
     end
 

--- a/lib/adama/version.rb
+++ b/lib/adama/version.rb
@@ -1,3 +1,3 @@
 module Adama
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/lib/adama/version.rb
+++ b/lib/adama/version.rb
@@ -1,3 +1,3 @@
 module Adama
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
Using `**kwargs` as a method parameter throwing error when used with ruby 3.2.2. Updating it to `kwargs` works fine. May be it is related to https://github.com/rails/rails/pull/46895

